### PR TITLE
Convar fix

### DIFF
--- a/lua/replicators/data.lua
+++ b/lua/replicators/data.lua
@@ -8,14 +8,28 @@ AddCSLuaFile( )
 
 //=================== Replicators settings ============================
 
-g_segments_to_assemble_replicator 	= 30
-g_segments_to_assemble_queen 		= 90
+REPLICATOR.Convars = {}
+REPLICATOR.Convars["tr_replicators_limit"] = CreateConVar("tr_replicators_limit", "30", FCVAR_NONE, "Limit for Replicator count")
+REPLICATOR.Convars["tr_replicators_collection_speed"] = CreateConVar("tr_replicators_collection_speed", "5", FCVAR_NONE, "Speed at which Replicators collect metal")
+REPLICATOR.Convars["tr_replicators_giving_speed"] = CreateConVar("tr_replicators_giving_speed", "10", FCVAR_NONE, "Sets the speed at which Replicators give metal")
+REPLICATOR.Convars["tr_replicators_dark_level"] = CreateConVar("tr_replicators_dark_level", "20", FCVAR_NONE, "Sets the light level that underwhich is considered dark for Replicators")
+REPLICATOR.Convars["tr_replicators_blocks_multiplier"] = CreateConVar("tr_replicators_blocks_multiplier", "1", FCVAR_NONE, "Multiplier for number of blocks required to (dis)assemble Replicators")
 
-g_replicator_collection_speed		= 30
-g_replicator_giving_speed			= 10
-g_replicator_limit					= 30
+function REPLICATOR:IsValid()
+	return true
+end
 
-g_replicator_min_dark_level			= 20
+function REPLICATOR:UpdateParameters()
+	g_replicator_limit = self.Convars["tr_replicators_limit"]:GetInt()
+	g_replicator_collection_speed = self.Convars["tr_replicators_collection_speed"]:GetInt()
+	g_replicator_giving_speed = self.Convars["tr_replicators_giving_speed"]:GetInt()
+	g_replicator_min_dark_level = self.Convars["tr_replicators_dark_level"]:GetInt()
+
+	local x = self.Convars["tr_replicators_blocks_multiplier"]:GetFloat()
+	g_segments_to_assemble_replicator = 30 * x
+	g_segments_to_assemble_queen = 90 * x
+end
+hook.Add("Think", REPLICATOR, REPLICATOR.UpdateParameters)
 
 //========================= Replicators data ===========================
 g_PathPoints 		= { }

--- a/lua/replicators/main.lua
+++ b/lua/replicators/main.lua
@@ -152,7 +152,7 @@ REPLICATOR.ReplicatorBreak = function( replicatorType, self, damage, dmgpos, ass
 
 	local t_Count = 0
 	
-	if replicatorType == 1 then t_Count = (GetConVar("tr_replicators_blocks_multiplier"):GetFloat() * 30)
+	if replicatorType == 1 then t_Count = g_segments_to_assemble_replicator
 	elseif replicatorType == 2 then t_Count = g_segments_to_assemble_queen
 	end
 	

--- a/lua/replicators/main.lua
+++ b/lua/replicators/main.lua
@@ -19,37 +19,6 @@ include( "replicators/walk.lua" )
 
 list.Add( "OverrideMaterials", "rust/rusty_paint" )
 
-concommand.Add( "tr_replicators_limit", function( ply, cmd, args )
-
-	g_replicator_limit = tonumber( agrs )
-	
-end )
-
-concommand.Add( "tr_replicators_collection_speed", function( ply, cmd, args )
-
-	g_replicator_collection_speed = tonumber( agrs )
-	
-end )
-
-concommand.Add( "tr_replicators_giving_speed", function( ply, cmd, args )
-
-	g_replicator_giving_speed = tonumber( agrs )
-	
-end )
-
-concommand.Add( "tr_replicators_dark_level", function( ply, cmd, args )
-
-	g_replicator_min_dark_level = tonumber( agrs )
-	
-end )
-
-concommand.Add( "tr_replicators_blocks_multiplier", function( ply, cmd, args )
-
-	g_segments_to_assemble_replicator 	= 30 * tonumber( agrs )
-	g_segments_to_assemble_queen 		= 90 * tonumber( agrs )
-
-end )
-
 REPLICATOR.ConvertToGrid = function( pos, size )
 
 	local t_Pos = pos / size
@@ -183,7 +152,7 @@ REPLICATOR.ReplicatorBreak = function( replicatorType, self, damage, dmgpos, ass
 
 	local t_Count = 0
 	
-	if replicatorType == 1 then t_Count = g_segments_to_assemble_replicator
+	if replicatorType == 1 then t_Count = (GetConVar("tr_replicators_blocks_multiplier"):GetFloat() * 30)
 	elseif replicatorType == 2 then t_Count = g_segments_to_assemble_queen
 	end
 	


### PR DESCRIPTION
Attempting to change Replicator parameters through the console commands caused their respective variables to become nil and produce errors; This overhaul fixes that.
