### PR TITLE
Replicators will now respect notarget

### DIFF
--- a/lua/replicators/ai.lua
+++ b/lua/replicators/ai.lua
@@ -522,7 +522,7 @@ REPLICATOR.ReplicatorAI = function( replicatorType, self  )
 								self:SetCollisionGroup( COLLISION_GROUP_PASSABLE_DOOR )
 								timer.Remove( "rRefind"..self:EntIndex() )
 
-								if m_Target:IsPlayer() or m_Target:IsNPC() then self:SetParent( m_Target, 1 )
+								if (m_Target:IsPlayer() and (not m_Target:IsFlagSet(FL_NOTARGET))) or m_Target:IsNPC() then self:SetParent( m_Target, 1 )
 								else self:SetParent( m_Target, -1 ) end
 								
 							end

--- a/lua/replicators/keron.lua
+++ b/lua/replicators/keron.lua
@@ -39,7 +39,7 @@ hook.Add( "EntityTakeDamage", "CNR_GetDamaged", function( target, dmginfo )
 	
 		local h_Attacker = dmginfo:GetAttacker()
 		
-		if not g_Attackers[ "r"..h_Attacker:EntIndex() ] and ( ( h_Attacker:IsPlayer() and h_Attacker:Alive() ) or h_Attacker:IsNPC() ) then
+		if not g_Attackers[ "r"..h_Attacker:EntIndex() ] and ( ( (h_Attacker:IsPlayer() and (not h_Attacker:IsFlagSet(FL_NOTARGET))) and h_Attacker:Alive() ) or h_Attacker:IsNPC() ) then
 		
 			g_Attackers[ "r"..h_Attacker:EntIndex() ] = h_Attacker
 			target.rParentReplicator.rResearch = true

--- a/lua/replicators/main.lua
+++ b/lua/replicators/main.lua
@@ -56,7 +56,7 @@ REPLICATOR.ReplicatorOnTakeDamage = function( replicatorType, self, dmginfo )
 	
 	self:SetHealth( self:Health() - h_Damage )
 
-	if not g_Attackers[ "r"..h_Attacker:EntIndex() ] and ( h_Attacker:IsNPC() or h_Attacker:IsPlayer() and h_Attacker:Alive() ) then
+	if not g_Attackers[ "r"..h_Attacker:EntIndex() ] and ( h_Attacker:IsNPC() or (h_Attacker:IsPlayer() and (not h_Attacker:IsFlagSet(FL_NOTARGET))) and h_Attacker:Alive() ) then
 	
 		g_Attackers[ "r"..h_Attacker:EntIndex() ] = h_Attacker
 		


### PR DESCRIPTION
Added checks to make Replicators ignore players with `FL_NOTARGET` set.
